### PR TITLE
WIP: symbolic opcode

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -41,6 +41,7 @@ let help_msg = [
     {|:elf <file>                    Load an ELF file|};
     {|:opcode <instr-set> <int>      Decode and execute opcode|};
     {|:sem <instr-set> <int>         Decode and print opcode semantics|};
+    {|:adhoc <instr-set> <int>       Adhoc symbolic opcode test|};
     {|:project <file>                Execute ASLi commands in <file>|};
     {|:q :quit                       Exit the interpreter|};
     {|:run                           Execute instructions|};
@@ -196,6 +197,9 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         let op = Z.of_string opcode in
         Printf.printf "Decoding instruction %s %s\n" iset (Z.format "%x" op);
         cpu'.sem iset op
+    | [":adhoc"] ->
+        let cpu' = Cpu.mkCPU cpu.env cpu.denv in
+        cpu'.adhoc "A64"
     | ":dump" :: iset :: opcode :: rest ->
         let fname =
             (match rest with

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -60,7 +60,7 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
     and adhoc (iset: string): unit =
         (* Construct add with immediate opcode parts. *)
         let hi = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 10) (Z.of_int 0x244))) in
-        let imm = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 12) (Z.of_int 42))) in
+        let imm = Exp (Expr_Var (Ident "imm")) in
         let lo = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 10) (Z.of_int 0x107))) in
 
         (* Append into 32-bit opcode. *)

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -8,6 +8,7 @@
 module AST = Asl_ast
 
 open Asl_utils
+open Symbolic
 
 type cpu = {
     env      : Eval.Env.t;
@@ -49,7 +50,7 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         Eval.eval_decode_case AST.Unknown env decoder op
 
     and sem (iset: string) (opcode: Primops.bigint): unit =
-        let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode) in
+        let op = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode)) in
         let decoder = Eval.Env.getDecoder env (Ident iset) in
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))

--- a/libASL/cpu.mli
+++ b/libASL/cpu.mli
@@ -15,6 +15,7 @@ type cpu = {
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
     sem      : string -> Primops.bigint -> unit;
+    adhoc    : string -> unit;
 }
 
 val mkCPU : Eval.Env.t -> Dis.env -> cpu

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -1312,37 +1312,37 @@ end
 
 
 
-let evaluation_environment (prelude: string) (files: string list) (verbose: bool) = 
+let evaluation_environment (prelude: string) (files: string list) (verbose: bool) =
     let t  = LoadASL.read_file prelude true verbose in
     let ts = List.map (fun filename ->
         if Utils.endswith filename ".spec" then begin
-            LoadASL.read_spec filename verbose 
+            LoadASL.read_spec filename verbose
         end else if Utils.endswith filename ".asl" then begin
-            LoadASL.read_file filename false verbose 
+            LoadASL.read_file filename false verbose
         end else if Utils.endswith filename ".prj" then begin
             [] (* ignore project files here and process later *)
         end else begin
             failwith ("Unrecognized file suffix on "^filename)
         end
-    ) files 
+    ) files
     in
     if verbose then Printf.printf "Building evaluation environment\n";
     (try
         Some (build_evaluation_environment (List.concat (t::ts)))
     with
     | Value.EvalError (loc, msg) ->
-        Printf.printf "  %s: Evaluation error: %s\n" (pp_loc loc) msg; 
+        Printf.printf "  %s: Evaluation error: %s\n" (pp_loc loc) msg;
         None
     )
 
-let aarch64_asl_dir: string option = 
+let aarch64_asl_dir: string option =
     List.nth_opt Res.Sites.aslfiles 0
 
-let aarch64_asl_files: (string * string list) option = 
-    let aarch64_file_load_order = 
+let aarch64_asl_files: (string * string list) option =
+    let aarch64_file_load_order =
        ["mra_tools/arch/regs.asl"; "mra_tools/types.asl"; "mra_tools/arch/arch.asl"; "mra_tools/arch/arch_instrs.asl"; "mra_tools/arch/regs_access.asl";
-        "mra_tools/arch/arch_decode.asl"; "mra_tools/support/aes.asl"; "mra_tools/support/barriers.asl"; "mra_tools/support/debug.asl"; 
-        "mra_tools/support/feature.asl"; "mra_tools/support/hints.asl"; "mra_tools/support/interrupts.asl"; "mra_tools/support/memory.asl"; 
+        "mra_tools/arch/arch_decode.asl"; "mra_tools/support/aes.asl"; "mra_tools/support/barriers.asl"; "mra_tools/support/debug.asl";
+        "mra_tools/support/feature.asl"; "mra_tools/support/hints.asl"; "mra_tools/support/interrupts.asl"; "mra_tools/support/memory.asl";
         "mra_tools/support/stubs.asl"; "mra_tools/support/fetchdecode.asl"; "tests/override.asl"; "tests/override.prj"]
     in Option.bind aarch64_asl_dir (fun dir ->
         let filenames = List.map (Filename.concat dir) aarch64_file_load_order in
@@ -1350,8 +1350,8 @@ let aarch64_asl_files: (string * string list) option =
         Some (prelude, filenames))
 
 (** XXX: .prj files NOT evaluated in this environment! *)
-let aarch64_evaluation_environment ?(verbose = false) (): Env.t option = 
-    Option.bind aarch64_asl_files 
+let aarch64_evaluation_environment ?(verbose = false) (): Env.t option =
+    Option.bind aarch64_asl_files
         (fun (prelude, filenames) -> evaluation_environment prelude filenames verbose)
 
 (****************************************************************

--- a/libASL/primops.ml
+++ b/libASL/primops.ml
@@ -230,6 +230,15 @@ let prim_in_mask (x: bitvector) (m: mask): bool =
 let prim_notin_mask (x: bitvector) (m: mask): bool =
     not (prim_in_mask x m)
 
+let mask_shift_right (m: mask) (n: int): mask =
+    assert(n <= m.n);
+    { n = m.n - n; v = Z.shift_right m.v n; m = Z.shift_right m.m n}
+
+let rec string_of_mask(m: mask): string =
+    if m.n == 0 then ""
+    else
+        let c = if Z.testbit m.m 0 then (if Z.testbit m.v 0 then "1" else "0") else "x" in
+        string_of_mask (mask_shift_right m 1) ^ c
 
 (****************************************************************)
 (** {2 Exception primops}                                       *)
@@ -345,8 +354,8 @@ let clear_ram (mem: ram) (d: char): unit =
     mem.contents <- Pages.empty;
     mem.default  <- Some d
 
-let defaultByte_ram (mem: ram) (addr: bigint): char = 
-    match mem.default with 
+let defaultByte_ram (mem: ram) (addr: bigint): char =
+    match mem.default with
     | None -> Char.chr Z.(to_int ((extract addr 0 8) lxor (extract addr 8 8)))
     | Some c -> c
 

--- a/libASL/primops.ml
+++ b/libASL/primops.ml
@@ -230,7 +230,13 @@ let prim_in_mask (x: bitvector) (m: mask): bool =
 let prim_notin_mask (x: bitvector) (m: mask): bool =
     not (prim_in_mask x m)
 
-let mask_shift_right (m: mask) (n: int): mask =
+let prim_mask_is_any (m: mask): bool =
+    Z.equal m.m Z.zero
+
+let prim_mask_extract (m: mask) (l: int) (h: int): mask =
+    { n = h-l+1; v = z_extract m.v l h; m = z_extract m.m l h }
+
+let prim_mask_shift_right (m: mask) (n: int): mask =
     assert(n <= m.n);
     { n = m.n - n; v = Z.shift_right m.v n; m = Z.shift_right m.m n}
 
@@ -238,7 +244,7 @@ let rec string_of_mask(m: mask): string =
     if m.n == 0 then ""
     else
         let c = if Z.testbit m.m 0 then (if Z.testbit m.v 0 then "1" else "0") else "x" in
-        string_of_mask (mask_shift_right m 1) ^ c
+        string_of_mask (prim_mask_shift_right m 1) ^ c
 
 (****************************************************************)
 (** {2 Exception primops}                                       *)

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -9,47 +9,6 @@ type sym =
   | Val of value
   | Exp of expr
 
-(** NOTE(mbm): aparently dead code?
-type 'a sym_pattern =
-  | SymPat_LitInt of bitsLit
-  | SymPat_LitHex of bitsLit
-  | SymPat_LitBits of bitsLit
-  | SymPat_LitMask of bitsLit
-  | SymPat_Const of ident
-  | SymPat_Wildcard
-  | SymPat_Tuple of pattern list
-  | SymPat_Set of pattern list
-  | SymPat_Range of 'a * 'a
-  | SymPat_Single of 'a
-
-type 'a sym_expr =
-  | SymExpr_If of 'a * 'a * ('a * 'a) list * 'a
-  | SymExpr_Binop of 'a * binop * 'a
-  | SymExpr_Unop of unop * 'a
-  | SymExpr_Field of 'a * ident
-  | SymExpr_Fields of 'a * ident list
-  | SymExpr_Slices of 'a * ('a * 'a) list
-  | SymExpr_In of 'a * 'a sym_pattern
-  | SymExpr_Var of ident
-  | SymExpr_Parens of 'a
-  | SymExpr_Tuple of 'a list
-  | SymExpr_Unknown of ty
-  | SymExpr_ImpDef of ty * string option
-  | SymExpr_TApply of ident * 'a list * 'a list
-  | SymExpr_Array of 'a * 'a
-  | SymExpr_LitInt of string
-  | SymExpr_LitHex of string
-  | SymExpr_LitReal of string
-  | SymExpr_LitBits of string
-  | SymExpr_LitMask of string
-  | SymExpr_LitString of string
-
-
-type sym' =
-  | Val' of value
-  | Exp' of ty * (sym' sym_expr)
-    *)
-
 let is_val (x: AST.expr): bool =
     (match x with
     | Expr_LitInt _ -> true

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -26,6 +26,7 @@ let rec val_expr (v: Value.value): AST.expr =
   | VInt n -> Expr_LitInt(Z.to_string n)
   | VReal n -> Expr_LitReal(Q.to_string n)
   | VBits {n; v} -> Expr_LitBits(Z.format ("%0" ^ string_of_int n ^ "b") v)
+  | VMask mask -> Expr_LitMask(string_of_mask mask)
   | VString s -> Expr_LitString(s)
   | VTuple vs -> Expr_Tuple(List.map val_expr vs)
   | _ -> failwith @@ "Casting unhandled value type to expression: " ^ pp_value v

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -9,6 +9,7 @@ type sym =
   | Val of value
   | Exp of expr
 
+(** NOTE(mbm): aparently dead code?
 type 'a sym_pattern =
   | SymPat_LitInt of bitsLit
   | SymPat_LitHex of bitsLit
@@ -47,6 +48,7 @@ type 'a sym_expr =
 type sym' =
   | Val' of value
   | Exp' of ty * (sym' sym_expr)
+    *)
 
 let is_val (x: AST.expr): bool =
     (match x with
@@ -171,6 +173,11 @@ let int_of_sym (e: sym): int =
   | Exp e        -> int_of_expr e
   | _ -> failwith @@ "int_of_sym: cannot coerce to int " ^ pp_sym e
 
+let bool_of_sym (s: sym): bool =
+  match s with
+  | Val (VBool b) -> b
+  | _ -> failwith @@ "bool_of_sym: cannot coerce to bool " ^ pp_sym s
+
 let sym_of_tuple (loc: AST.l) (v: sym): sym list  =
   match v with
   | Val (VTuple vs) -> (List.map (fun v -> Val v) vs)
@@ -282,7 +289,7 @@ let vint_eq cmp = function
   | _ -> false
 
 let is_zero = vint_eq Z.zero
-let is_one = vint_eq Z.one 
+let is_one = vint_eq Z.one
 
 let eval_lit (x: sym) =
   match x with
@@ -334,7 +341,7 @@ let sym_sub_int loc (x: sym) (y: sym) =
       let n = Z.of_string v in
       let e = Expr_LitInt (Z.to_string (Z.sub n y)) in
       Exp (Expr_TApply (FIdent ("add_int", 0), [], [x1; e]))
-  (* Elim term *) 
+  (* Elim term *)
   | (Exp x, Exp y) when is_pure_exp y ->
       (match find_elim_term loc x (fun v -> if y = v then Some (Val (VInt Z.zero)) else None) with
       | Some e -> e
@@ -438,7 +445,7 @@ let rec sym_append_bits (loc: l) (xw: int) (yw: int) (x: sym) (y: sym): sym =
 
   (* Match append of top-bit replicate expressions, turn into sign extend *)
   | (Exp (Expr_TApply (FIdent ("replicate_bits", 0), [Expr_LitInt "1"; w], [e;_])), Exp r) when sym_slice loc (Exp r) (yw - 1) 1 = Exp e ->
-      Exp (Expr_TApply (FIdent ("SignExtend", 0), [int_expr yw;int_expr (xw+yw)], [r; int_expr (xw + yw)])) 
+      Exp (Expr_TApply (FIdent ("SignExtend", 0), [int_expr yw;int_expr (xw+yw)], [r; int_expr (xw + yw)]))
 
   | (x,y) ->
     Exp (expr_prim' "append_bits" [expr_of_int xw; expr_of_int yw] [sym_expr x;sym_expr y])
@@ -546,7 +553,7 @@ let sym_zero_extend num_zeros old_width e =
       Exp (expr_prim' "ZeroExtend" [expr_of_int old_width; n'] [sym_expr e; n'])
 
 let sym_sign_extend num_zeros old_width (e: sym): sym =
-  match e with 
+  match e with
   | Exp (Expr_TApply (FIdent ("ZeroExtend",0), [Expr_LitInt oldsize; Expr_LitInt newsize], [x; _])) ->
     let size' = string_of_int (num_zeros + int_of_string newsize) in
     Exp (Expr_TApply (FIdent ("ZeroExtend",0), [Expr_LitInt oldsize; Expr_LitInt size'], [x; Expr_LitInt size']))
@@ -659,7 +666,7 @@ let sym_prim_simplify (name: string) (tes: sym list) (es: sym list): sym option 
   | ("add_int",     _,                [x1; x2]) ->
       Some (sym_add_int loc x1 x2)
 
-  | ("sub_int",     _,                [x1; x2]) -> 
+  | ("sub_int",     _,                [x1; x2]) ->
       Some (sym_sub_int loc x1 x2)
 
 

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -3,6 +3,7 @@ module Env = Eval.Env
 
 open AST
 open Value
+open Symbolic
 open Asl_utils
 
 (****************************************************************
@@ -384,7 +385,7 @@ let op_dis (env: Env.t) (iset: string) (op: value): stmt list opresult =
   let lenv = Dis.build_env env in
   let decoder = Eval.Env.getDecoder env (Ident iset) in
   try
-    let stmts = Dis.dis_decode_entry env lenv decoder op in
+    let stmts = Dis.dis_decode_entry env lenv decoder (Val op) in
     Result.Ok stmts
   with
     | e -> Result.Error (Op_DisFail e)
@@ -460,7 +461,7 @@ let get_opcodes (opt_verbose: bool ref) (iset: string) (instr: string) (env: Env
       let t = enumerate_encoding enc (field_vals_flags_only enc) in
       let l = list_of_enc_tree t in
       let opcodes = (match get_opcodes nm with
-      | [||] -> 
+      | [||] ->
         None
       | ops ->
           Some (List.fold_left (fun codes op ->

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -463,20 +463,20 @@ let eval_concat (loc: AST.l) (xs: value list): value =
  *)
 
 let eval_unknown_bits (wd: Primops.bigint): value =
-  if !concrete_unknown then 
+  if !concrete_unknown then
     VBits (Primops.mkBits (Z.to_int wd) Z.zero)
   else
     VUninitialized (Type_Bits (Expr_LitInt (Z.to_string wd)))
 
 let eval_unknown_ram (a: Primops.bigint): value =
-  if !concrete_unknown then 
+  if !concrete_unknown then
     VRAM (Primops.init_ram (char_of_int 0))
   else
     VUninitialized (type_builtin "__RAM")
 
-let eval_unknown_integer (_: unit): value = if !concrete_unknown then VInt Z.zero else VUninitialized (type_builtin "integer") 
-let eval_unknown_real    (_: unit): value = if !concrete_unknown then VReal Q.zero else VUninitialized (type_builtin "real") 
-let eval_unknown_string  (_: unit): value = if !concrete_unknown then VString "<UNKNOWN string>" else VUninitialized (type_builtin "string") 
+let eval_unknown_integer (_: unit): value = if !concrete_unknown then VInt Z.zero else VUninitialized (type_builtin "integer")
+let eval_unknown_real    (_: unit): value = if !concrete_unknown then VReal Q.zero else VUninitialized (type_builtin "real")
+let eval_unknown_string  (_: unit): value = if !concrete_unknown then VString "<UNKNOWN string>" else VUninitialized (type_builtin "string")
 
 
 (****************************************************************


### PR DESCRIPTION
This PR shows adhoc support for symbolic opcodes.

## Changes

* The `op` argument to `dis_decode_entry` is changed from `value` to `sym` type. This change cascades throughout the `dis` functions.
* Extend the `sym_inmask` implementation with simplification rules.
* Adds some operations on masks to `primops`.
* Hacks in an `asli` `:adhoc` command for testing purposes. We would need an actual user interface if we were going to land this.
* (Unfortunately, my editor has also polluted the PR by removing whitespace and end of lines.)

## Example

For comparison, when you ask for semantics for a concrete add immediate:
```
asm: add x7, x8, #291
opcode: 91048d07

Decoding instruction A64 91048d07
__array _R [ 7 ] = add_bits.0 {{ 64 }} ( __array _R [ 8 ],'0000000000000000000000000000000000000000000000000000000100100011' ) ;
```

ASLp can now execute opcodes that are expressions. For example the assembly template `add x7, x8, #<imm>` would be the opcode concatenation `0x244:imm:0x107`. It now gives the semantics:

```
__array _R [ 7 ] = add_bits.0 {{ 64 }} ( __array _R [ 8 ],append_bits.0 {{ 52,12 }} ( '0000000000000000000000000000000000000000000000000000',imm [ 0 +: 12 ] ) ) ;
```