### PR TITLE
symbolic opcodes

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -193,7 +193,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         Printf.printf "Decoding instruction %s %s\n" iset opcode;
         cpu'.sem iset opcode
     | ":ast" :: iset :: opcode :: rest when List.length rest <= 1 ->
-        let op = (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode)))) in
+        let (op, _) = sym_bits_of_string opcode in
         let decoder = Eval.Env.getDecoder cpu.env (Ident iset) in
         let chan_opt = Option.map open_out (List.nth_opt rest 0) in
         let chan = Option.value chan_opt ~default:stdout in

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -41,9 +41,8 @@ let help_msg = [
     {|:? :help                       Show this help message|};
     {|:elf <file>                    Load an ELF file|};
     {|:opcode <instr-set> <int>      Decode and execute opcode|};
-    {|:adhoc <instr-set> <int>       Adhoc symbolic opcode test|};
-    {|:sem <instr-set> <int>         Decode and print opcode semantics|};
-    {|:ast <instr-set> <int> [file]  Decode and write opcode semantics to stdout or a file, in a structured ast format|};
+    {|:sem <instr-set> <bits>        Decode and print opcode semantics|};
+    {|:ast <instr-set> <bits> [file] Decode and write opcode semantics to stdout or a file, in a structured ast format|};
     {|:gen <instr-set> <regex>       Generate an offline lifter using the given backend|};
     {|      [pc-option] [backend] [dir]|};
     {|:project <file>                Execute ASLi commands in <file>|};
@@ -191,9 +190,8 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         ) encodings;
     | [":sem"; iset; opcode] ->
         let cpu' = Cpu.mkCPU cpu.env cpu.denv in
-        let op = Z.of_string opcode in
-        Printf.printf "Decoding instruction %s %s\n" iset (Z.format "%x" op);
-        cpu'.sem iset op
+        Printf.printf "Decoding instruction %s %s\n" iset opcode;
+        cpu'.sem iset opcode
     | ":ast" :: iset :: opcode :: rest when List.length rest <= 1 ->
         let op = (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode)))) in
         let decoder = Eval.Env.getDecoder cpu.env (Ident iset) in
@@ -222,9 +220,6 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         let cpu' = Cpu.mkCPU cpu.env cpu.denv in
         cpu'.gen iset id pc_option backend dir;
         Printf.printf "Done generating %s lifter into '%s'.\n" backend_str dir;
-    | [":adhoc"; iset; opcode] ->
-        let cpu' = Cpu.mkCPU cpu.env cpu.denv in
-        cpu'.adhoc iset opcode
     | ":dump" :: iset :: opcode :: rest ->
         let fname = 
             (match rest with 

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -222,9 +222,9 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         let cpu' = Cpu.mkCPU cpu.env cpu.denv in
         cpu'.gen iset id pc_option backend dir;
         Printf.printf "Done generating %s lifter into '%s'.\n" backend_str dir;
-    | [":adhoc"] ->
+    | [":adhoc"; iset; opcode] ->
         let cpu' = Cpu.mkCPU cpu.env cpu.denv in
-        cpu'.adhoc "A64"
+        cpu'.adhoc iset opcode
     | ":dump" :: iset :: opcode :: rest ->
         let fname = 
             (match rest with 

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -10,6 +10,7 @@ open List
 open Array
 open Asl_ast
 open Value
+open Symbolic
 open Eval
 open Asl_utils
 open Lwt
@@ -24,7 +25,8 @@ let eval_instr (opcode: string) : string * string =
     let env' = Lazy.force persistent_env in
     let lenv = Dis.build_env env' in
     let decoder = Eval.Env.getDecoder env' (Ident "A64") in
-    let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode)))) in
+    let (op, _) = sym_bits_of_string opcode in
+    let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder op in
 
     let stmts'   = List.map pp_raw stmts in
     enc, String.concat "\n" stmts'

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -24,7 +24,7 @@ let eval_instr (opcode: string) : string * string =
     let env' = Lazy.force persistent_env in
     let lenv = Dis.build_env env' in
     let decoder = Eval.Env.getDecoder env' (Ident "A64") in
-    let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder (Z.of_string opcode) in
+    let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode)))) in
 
     let stmts'   = List.map pp_raw stmts in
     enc, String.concat "\n" stmts'
@@ -96,4 +96,3 @@ let () = Arg.parse speclist ignore "usage: aslp-server --host HOSTNAME --port PO
 let () =
   let _address = Unix.(ADDR_INET (inet_addr_of_string !addr_opt, !port_opt)) in
   Lwt_main.run (server !addr_opt !port_opt)
-

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -26,8 +26,7 @@ type cpu = {
     setPC    : Primops.bigint -> unit;
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
-    sem      : string -> Primops.bigint -> unit;
-    adhoc    : string -> string -> unit;
+    sem      : string -> string -> unit;
     gen      : string -> string -> bool -> gen_backend -> string -> unit;
 }
 
@@ -57,19 +56,12 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         let decoder = Eval.Env.getDecoder env (Ident iset) in
         Eval.eval_decode_case AST.Unknown env decoder opcode
 
-    and sem (iset: string) (opcode: Primops.bigint): unit =
+    and sem (iset: string) (opcode: string): unit =
         let decoder = Eval.Env.getDecoder env (Ident iset) in
+        let (op, _) = sym_bits_of_string opcode in
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))
-            (Dis.dis_decode_entry env denv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode))))
-
-    and adhoc (iset: string) (opcode: string): unit =
-        let (op, _) = sym_opcode_of_string opcode in
-
-        let decoder = Eval.Env.getDecoder env (Ident iset) in
-        List.iter
-            (fun s -> Printf.printf "%s\n" (pp_stmt s))
-            (Dis.dis_decode_entry env denv decoder op) 
+            (Dis.dis_decode_entry env denv decoder op)
         
     and gen (iset: string) (pat: string) (include_pc: bool) (backend: gen_backend) (dir: string): unit =
         if not (Sys.file_exists dir) then failwith ("Can't find target dir " ^ dir);
@@ -98,7 +90,6 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         elfwrite = elfwrite;
         opcode   = opcode;
         sem      = sem;
-        adhoc    = adhoc;
         gen      = gen
     }
 

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -64,13 +64,8 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
             (Dis.dis_decode_entry env denv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode))))
 
     and adhoc (iset: string): unit =
-        (* Construct add with immediate opcode parts. *)
-        let hi = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 10) (Z.of_int 0x244))) in
-        let imm = Exp (Expr_Var (Ident "imm")) in
-        let lo = Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 10) (Z.of_int 0x107))) in
-
-        (* Append into 32-bit opcode. *)
-        let op = sym_append_bits Unknown 10 22 hi (sym_append_bits Unknown 12 10 imm lo) in
+        let opcode = "0x244:10 imm:12 0x107:10" in
+        let (op, _) = sym_opcode_of_string opcode in
 
         let decoder = Eval.Env.getDecoder env (Ident iset) in
         List.iter

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -27,7 +27,7 @@ type cpu = {
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
     sem      : string -> Primops.bigint -> unit;
-    adhoc    : string -> unit;
+    adhoc    : string -> string -> unit;
     gen      : string -> string -> bool -> gen_backend -> string -> unit;
 }
 
@@ -63,8 +63,7 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
             (fun s -> Printf.printf "%s\n" (pp_stmt s))
             (Dis.dis_decode_entry env denv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode))))
 
-    and adhoc (iset: string): unit =
-        let opcode = "0x244:10 imm:12 0x107:10" in
+    and adhoc (iset: string) (opcode: string): unit =
         let (op, _) = sym_opcode_of_string opcode in
 
         let decoder = Eval.Env.getDecoder env (Ident iset) in

--- a/libASL/cpu.mli
+++ b/libASL/cpu.mli
@@ -21,8 +21,7 @@ type cpu = {
     setPC    : Primops.bigint -> unit;
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
-    sem      : string -> Primops.bigint -> unit;
-    adhoc    : string -> string -> unit;
+    sem      : string -> string -> unit;
     gen      : string -> string -> bool -> gen_backend -> string -> unit;
 }
 

--- a/libASL/cpu.mli
+++ b/libASL/cpu.mli
@@ -22,6 +22,7 @@ type cpu = {
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
     sem      : string -> Primops.bigint -> unit;
+    adhoc    : string -> unit;
     gen      : string -> string -> bool -> gen_backend -> string -> unit;
 }
 

--- a/libASL/cpu.mli
+++ b/libASL/cpu.mli
@@ -22,7 +22,7 @@ type cpu = {
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
     sem      : string -> Primops.bigint -> unit;
-    adhoc    : string -> unit;
+    adhoc    : string -> string -> unit;
     gen      : string -> string -> bool -> gen_backend -> string -> unit;
 }
 

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -14,7 +14,6 @@ module TC   = Tcheck
 open AST
 open Asl_utils
 open Value
-
 open Symbolic
 
 module StringCmp = struct
@@ -1421,24 +1420,28 @@ and dis_stmt' (x: AST.stmt): unit rws =
         DisEnv.write [Stmt_Assert(expr_false, loc)]
     )
 
-let dis_encoding (x: encoding) (op: Primops.bigint): bool rws =
+
+let dis_encoding (x: encoding) (op: sym): bool rws =
     let Encoding_Block (nm, iset, fields, opcode, guard, unpreds, b, loc) = x in
     (* todo: consider checking iset *)
     (* Printf.printf "Checking opcode match %s == %s\n" (Utils.to_string (PP.pp_opcode_value opcode)) (pp_value op); *)
-    match Eval.eval_opcode_guard loc opcode op with
-    | Some op ->
+    let ok = (match opcode with
+    | Opcode_Bits b -> sym_eq     loc op (Val (from_bitsLit b))
+    | Opcode_Mask m -> sym_inmask loc op (to_mask loc (from_maskLit m))
+    ) in
+    if (bool_of_sym ok) then begin
         if !Eval.trace_instruction then Printf.printf "TRACE: instruction %s\n" (pprint_ident nm);
 
         let@ () = DisEnv.traverse_ (function (IField_Field (f, lo, wd)) ->
-            let v = extract_bits' loc op lo wd in
-            if !Eval.trace_instruction then Printf.printf "      %s = %s\n" (pprint_ident f) (pp_value v);
-            declare_assign_var Unknown (val_type v) f (Val v)
+            let s = sym_extract_bits loc op (sym_of_int lo) (sym_of_int wd) in
+            if !Eval.trace_instruction then Printf.printf "      %s = %s\n" (pprint_ident f) (pp_sym s);
+            declare_assign_var Unknown (sym_type s) f s
         ) fields in
 
         let@ guard' = dis_expr loc guard in
         if to_bool loc (sym_value_unsafe guard') then begin
             List.iter (fun (i, b) ->
-                if eval_eq loc (extract_bits' loc op i 1) (from_bitsLit b) then
+                if eval_eq loc (sym_value_unsafe (sym_extract_bits loc op (sym_of_int i) (sym_of_int 1))) (from_bitsLit b) then
                     raise (Throw (loc, Exc_Unpredictable))
             ) unpreds;
             (* dis_encoding: we cannot guarantee that these statements are fully evaluated. *)
@@ -1447,28 +1450,36 @@ let dis_encoding (x: encoding) (op: Primops.bigint): bool rws =
         end else begin
             DisEnv.pure false
         end
-    | None -> DisEnv.pure false
+    end else begin
+        DisEnv.pure false
+    end
 
-let dis_decode_slice (loc: l) (x: decode_slice) (op: Primops.bigint): value rws =
+let rec dis_decode_pattern (loc: AST.l) (x: decode_pattern) (op: sym): sym =
+    match x with
+    | DecoderPattern_Bits     b -> sym_eq     loc op (Val (from_bitsLit b))
+    | DecoderPattern_Mask     m -> sym_inmask loc op (to_mask loc (from_maskLit m))
+    | DecoderPattern_Wildcard _ -> sym_true
+    | DecoderPattern_Not      p -> sym_not_bool loc (dis_decode_pattern loc p op)
+    
+let dis_decode_slice (loc: l) (x: decode_slice) (op: sym): sym rws =
     (match x with
     | DecoderSlice_Slice (lo, wd) ->
-        let op = Value.from_bitsInt (lo+wd) op in
-        DisEnv.pure @@ extract_bits' loc op lo wd
+        (*let op = Value.from_bitsInt (lo+wd) op in*)
+        DisEnv.pure @@ sym_extract_bits loc op (sym_of_int lo) (sym_of_int wd)
     | DecoderSlice_FieldName f ->
-        (* assumes expression always evaluates to concrete value. *)
-        let+ _,f' = DisEnv.getVar loc f in sym_value_unsafe f'
+        let+ _,f' = DisEnv.getVar loc f in f'
     | DecoderSlice_Concat fs ->
         (* assumes expression always evaluates to concrete value. *)
         let+ fs' = DisEnv.traverse (DisEnv.getVar loc) fs in
-        eval_concat loc (List.map (fun (_,s) -> sym_value_unsafe s) fs')
+        sym_concat loc (List.map (fun (t,s) -> (width_of_type loc t, s)) fs')
     )
 
 (* Duplicate of eval_decode_case modified to print rather than eval *)
-let rec dis_decode_case (loc: AST.l) (x: decode_case) (op: Primops.bigint): string rws =
+let rec dis_decode_case (loc: AST.l) (x: decode_case) (op: sym): string rws =
     let body = dis_decode_case' loc x op in
     if no_debug() then body
     else DisEnv.scope loc "dis_decode_case" (pp_decode_case x) Fun.id body
-and dis_decode_case' (loc: AST.l) (x: decode_case) (op: Primops.bigint): string rws =
+and dis_decode_case' (loc: AST.l) (x: decode_case) (op: sym): string rws =
     (match x with
     | DecoderCase_Case (ss, alts, loc) ->
             let@ vs = DisEnv.traverse (fun s -> dis_decode_slice loc s op) ss in
@@ -1487,12 +1498,12 @@ and dis_decode_case' (loc: AST.l) (x: decode_case) (op: Primops.bigint): string 
     )
 
 (* Duplicate of eval_decode_alt modified to print rather than eval *)
-and dis_decode_alt (loc: l) (x: decode_alt) (vs: value list) (op: Primops.bigint): string option rws =
-    let body = dis_decode_alt' loc x vs op in
+and dis_decode_alt (loc: l) (x: decode_alt) (ss: sym list) (op: sym): string option rws =
+    let body = dis_decode_alt' loc x ss op in
     if no_debug() then body
     else DisEnv.scope loc "dis_decode_alt" (pp_decode_alt x) Option.(fold ~none:"(unmatched)" ~some:Fun.id) body
-and dis_decode_alt' (loc: AST.l) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: Primops.bigint): string option rws =
-    if List.for_all2 (Eval.eval_decode_pattern loc) ps vs then
+and dis_decode_alt' (loc: AST.l) (DecoderAlt_Alt (ps, b)) (ss: sym list) (op: sym): string option rws =
+    if List.for_all2 (fun p s -> (bool_of_sym (dis_decode_pattern loc p s))) ps ss then
         (match b with
         | DecoderBody_UNPRED loc -> raise (Throw (loc, Exc_Unpredictable))
         | DecoderBody_UNALLOC loc -> raise (Throw (loc, Exc_Undefined))
@@ -1535,9 +1546,8 @@ and dis_decode_alt' (loc: AST.l) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: 
         | DecoderBody_Decoder (fs, c, loc) ->
                 let@ () = DisEnv.modify (LocalEnv.addLevel) in
                 let@ () = DisEnv.traverse_ (function (IField_Field (f, lo, wd)) ->
-                    let op = Value.from_bitsInt (lo+wd) op in
-                    let v = extract_bits' loc op lo wd in
-                    declare_assign_var loc (val_type v) f (Val v)
+                    let s = sym_extract_bits loc op (sym_of_int lo) (sym_of_int wd) in
+                    declare_assign_var loc (sym_type s) f s
                 ) fs
                 in
                 let@ result = dis_decode_case loc c op in
@@ -1559,7 +1569,7 @@ let enum_types env i =
     | _ -> None
 
 (* Actually perform dis *)
-let dis_core (env: Eval.Env.t) (unroll_bound) ((lenv,globals): env) (decode: decode_case) (op: Primops.bigint): string * stmt list =
+let dis_core (env: Eval.Env.t) (unroll_bound) ((lenv,globals): env) (decode: decode_case) (op: sym): string * stmt list =
     let DecoderCase_Case (_,_,loc) = decode in
     let config = { eval_env = env ; unroll_bound } in
 
@@ -1594,7 +1604,7 @@ let dis_core (env: Eval.Env.t) (unroll_bound) ((lenv,globals): env) (decode: dec
    This is a complete hack, but it is nicer to make the loop unrolling decision during
    partial evaluation, rather than having to unroll after we know vectorization failed.
  *)
-let dis_decode_entry_with_inst (env: Eval.Env.t) ((lenv,globals): env) (decode: decode_case) (op: Primops.bigint): string * stmt list =
+let dis_decode_entry_with_inst (env: Eval.Env.t) ((lenv,globals): env) (decode: decode_case) (op: sym): string * stmt list =
   let max_upper_bound = Z.of_int64 Int64.max_int in
   match !Symbolic.use_vectoriser with
   | false -> dis_core env max_upper_bound (lenv,globals) decode op
@@ -1604,7 +1614,7 @@ let dis_decode_entry_with_inst (env: Eval.Env.t) ((lenv,globals): env) (decode: 
     if res then (enc,stmts') else
       dis_core env max_upper_bound (lenv,globals) decode op
 
-let dis_decode_entry (env: Eval.Env.t) ((lenv,globals): env) (decode: decode_case) (op: Primops.bigint): stmt list =
+let dis_decode_entry (env: Eval.Env.t) ((lenv,globals): env) (decode: decode_case) (op: sym): stmt list =
   snd @@ dis_decode_entry_with_inst env (lenv,globals) decode op
 
 let build_env (env: Eval.Env.t): env =
@@ -1650,4 +1660,4 @@ let retrieveDisassembly ?(address:string option) (env: Eval.Env.t) (lenv: env) (
     let lenv = match address with
     | Some v -> setPC env lenv (Z.of_string v)
     | None -> lenv in
-    dis_decode_entry env lenv decoder (Z.of_string opcode)
+    dis_decode_entry env lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode))))

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -958,6 +958,6 @@ let sym_opcode_segment_of_string (s: string): sym * int =
   | _ -> failwith ("invalid opcode segment")
 
 let sym_opcode_of_string (s: string): sym * int =
-  let segs = List.map sym_opcode_segment_of_string (String.split_on_char ' ' s) in
+  let segs = List.map sym_opcode_segment_of_string (String.split_on_char '|' s) in
   let init = (Val (VBits empty_bits), 0) in
   List.fold_left (fun (x, xw) (y, yw) -> (sym_append_bits Unknown xw yw x y, xw+yw)) init segs

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -177,6 +177,11 @@ let int_of_sym (e: sym): int =
   | Exp e        -> int_of_expr e
   | _ -> failwith @@ "int_of_sym: cannot coerce to int " ^ pp_sym e
 
+let bool_of_sym (s: sym): bool =
+  match s with
+  | Val (VBool b) -> b
+  | _ -> failwith @@ "bool_of_sym: cannot coerce to bool " ^ pp_sym s  
+  
 let sym_of_tuple (loc: AST.l) (v: sym): sym list  =
   match v with
   | Val (VTuple vs) -> (List.map (fun v -> Val v) vs)

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -4,6 +4,7 @@ module Env = Eval.Env
 open AST
 open Value
 open Asl_utils
+open Symbolic
 
 (****************************************************************
  * Opcode decoding without evaluation.
@@ -380,7 +381,7 @@ let op_dis (env: Env.t) (iset: string) (op: Primops.bigint): stmt list opresult 
   let lenv = Dis.build_env env in
   let decoder = Eval.Env.getDecoder env (Ident iset) in
   try
-    let stmts = Dis.dis_decode_entry env lenv decoder op in
+    let stmts = Dis.dis_decode_entry env lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
     Result.Ok stmts
   with
     | e -> Result.Error (Op_DisFail e)

--- a/tests/aslt/test_cntlm_vec.t
+++ b/tests/aslt/test_cntlm_vec.t
@@ -6,129 +6,129 @@
 
   $ cat stmts
   "0x0e011800"
-  Decoding instruction A64 e011800
+  Decoding instruction A64 0x0e011800
   constant bits ( 128 ) Exp8__5 = __array _Z [ 0 ] ;
   constant bits ( 128 ) Exp10__5 = __array _Z [ 1 ] ;
   bits ( 64 ) result__4 ;
   result__4 = shuffle_vec.0 {{ 8,8,8 }} ( Exp10__5 [ 0 +: 64 ],Exp8__5 [ 0 +: 64 ],'0000000000000000000000000000111000000000000000000000000000001100000000000000000000000000000010100000000000000000000000000000100000000000000000000000000000000110000000000000000000000000000001000000000000000000000000000000001000000000000000000000000000000000' ) ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x0e040ea8"
-  Decoding instruction A64 e040ea8
+  Decoding instruction A64 0x0e040ea8
   constant bits ( 64 ) Exp6__5 = __array _R [ 21 ] ;
   bits ( 64 ) result__4 ;
   result__4 = replicate_bits.0 {{ 32,2 }} ( Exp6__5 [ 0 +: 32 ],2 ) ;
   __array _Z [ 8 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x0e211c00"
-  Decoding instruction A64 e211c00
+  Decoding instruction A64 0x0e211c00
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( and_bits.0 {{ 64 }} ( __array _Z [ 0 ] [ 0 +: 64 ],__array _Z [ 1 ] [ 0 +: 64 ] ),128 ) ;
   "0x0ea00800"
-  Decoding instruction A64 ea00800
+  Decoding instruction A64 0x0ea00800
   bits ( 64 ) result__4 ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( Elem.set.0 {{ 64,32 }} ( Elem.set.0 {{ 64,32 }} ( result__4,1,32,Elem.read.0 {{ 64,32 }} ( __array _Z [ 0 ] [ 0 +: 64 ],0,32 ) ),0,32,Elem.read.0 {{ 64,32 }} ( __array _Z [ 0 ] [ 0 +: 64 ],1,32 ) ),128 ) ;
   "0x0ea00801"
-  Decoding instruction A64 ea00801
+  Decoding instruction A64 0x0ea00801
   bits ( 64 ) result__4 ;
   __array _Z [ 1 ] = ZeroExtend.0 {{ 64,128 }} ( Elem.set.0 {{ 64,32 }} ( Elem.set.0 {{ 64,32 }} ( result__4,1,32,Elem.read.0 {{ 64,32 }} ( __array _Z [ 0 ] [ 0 +: 64 ],0,32 ) ),0,32,Elem.read.0 {{ 64,32 }} ( __array _Z [ 0 ] [ 0 +: 64 ],1,32 ) ),128 ) ;
   "0x0ea03020"
-  Decoding instruction A64 ea03020
+  Decoding instruction A64 0x0ea03020
   constant bits ( 128 ) Exp8__5 = __array _Z [ 1 ] ;
   constant bits ( 128 ) Exp11__6 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = sub_vec.0 {{ 2,64 }} ( trunc_vec.0 {{ 2,64,128 }} ( scast_vec.0 {{ 2,128,64 }} ( Exp8__5 [ 0 +: 128 ],2,128 ),2,64 ),trunc_vec.0 {{ 2,64,128 }} ( scast_vec.0 {{ 2,128,32 }} ( Exp11__6 [ 0 +: 64 ],2,128 ),2,64 ),2 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x0ea18508"
-  Decoding instruction A64 ea18508
+  Decoding instruction A64 0x0ea18508
   constant bits ( 128 ) Exp7__5 = __array _Z [ 8 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 1 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( Exp7__5 [ 0 +: 64 ],Exp9__5 [ 0 +: 64 ],2 ) ;
   __array _Z [ 8 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x0ea48400"
-  Decoding instruction A64 ea48400
+  Decoding instruction A64 0x0ea48400
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 4 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( Exp7__5 [ 0 +: 64 ],Exp9__5 [ 0 +: 64 ],2 ) ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x0f000420"
-  Decoding instruction A64 f000420
+  Decoding instruction A64 0x0f000420
   __array _Z [ 0 ] = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000001' ;
   "0x0f000428"
-  Decoding instruction A64 f000428
+  Decoding instruction A64 0x0f000428
   __array _Z [ 8 ] = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000001' ;
   "0x0f07e7c1"
-  Decoding instruction A64 f07e7c1
+  Decoding instruction A64 0x0f07e7c1
   __array _Z [ 1 ] = '00000000000000000000000000000000000000000000000000000000000000001111111011111110111111101111111011111110111111101111111011111110' ;
   "0x0f20a402"
-  Decoding instruction A64 f20a402
+  Decoding instruction A64 0x0f20a402
   constant bits ( 128 ) Exp9__6 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = scast_vec.0 {{ 2,64,32 }} ( Exp9__6 [ 0 +: 64 ],2,64 ) ;
   __array _Z [ 2 ] = result__4 ;
   "0x0f20a423"
-  Decoding instruction A64 f20a423
+  Decoding instruction A64 0x0f20a423
   constant bits ( 128 ) Exp9__6 = __array _Z [ 1 ] ;
   bits ( 128 ) result__4 ;
   result__4 = scast_vec.0 {{ 2,64,32 }} ( Exp9__6 [ 0 +: 64 ],2,64 ) ;
   __array _Z [ 3 ] = result__4 ;
   "0x2e200800"
-  Decoding instruction A64 2e200800
+  Decoding instruction A64 0x2e200800
   bits ( 64 ) result__4 ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( result__4,3,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],0,8 ) ),2,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],1,8 ) ),1,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],2,8 ) ),0,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],3,8 ) ),7,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],4,8 ) ),6,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],5,8 ) ),5,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],6,8 ) ),4,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 0 ] [ 0 +: 64 ],7,8 ) ),128 ) ;
   "0x2e200820"
-  Decoding instruction A64 2e200820
+  Decoding instruction A64 0x2e200820
   bits ( 64 ) result__4 ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( Elem.set.0 {{ 64,8 }} ( result__4,3,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],0,8 ) ),2,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],1,8 ) ),1,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],2,8 ) ),0,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],3,8 ) ),7,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],4,8 ) ),6,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],5,8 ) ),5,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],6,8 ) ),4,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],7,8 ) ),128 ) ;
   "0x2e211c00"
-  Decoding instruction A64 2e211c00
+  Decoding instruction A64 0x2e211c00
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( eor_bits.0 {{ 64 }} ( __array _Z [ 1 ] [ 0 +: 64 ],eor_bits.0 {{ 64 }} ( '0000000000000000000000000000000000000000000000000000000000000000',__array _Z [ 0 ] [ 0 +: 64 ] ) ),128 ) ;
   "0x2f000400"
-  Decoding instruction A64 2f000400
+  Decoding instruction A64 0x2f000400
   __array _Z [ 0 ] = '00000000000000000000000000000000000000000000000000000000000000001111111111111111111111111111111111111111111111111111111111111111' ;
   "0x2f03d7e0"
-  Decoding instruction A64 2f03d7e0
+  Decoding instruction A64 0x2f03d7e0
   __array _Z [ 0 ] = '00000000000000000000000000000000000000000000000000000000000000001111111110000000000000000000000011111111100000000000000000000000' ;
   "0x2f044400"
-  Decoding instruction A64 2f044400
+  Decoding instruction A64 0x2f044400
   __array _Z [ 0 ] = '00000000000000000000000000000000000000000000000000000000000000001111111101111111111111111111111111111111011111111111111111111111' ;
   "0x2f280400"
-  Decoding instruction A64 2f280400
+  Decoding instruction A64 0x2f280400
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,16 }} ( replicate_bits.0 {{ 16,2 }} ( '0000000000011000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x2f280424"
-  Decoding instruction A64 2f280424
+  Decoding instruction A64 0x2f280424
   constant bits ( 128 ) Exp7__5 = __array _Z [ 1 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,16 }} ( replicate_bits.0 {{ 16,2 }} ( '0000000000011000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 4 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x2f300423"
-  Decoding instruction A64 2f300423
+  Decoding instruction A64 0x2f300423
   constant bits ( 128 ) Exp7__5 = __array _Z [ 1 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,16 }} ( replicate_bits.0 {{ 16,2 }} ( '0000000000010000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 3 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x2f300446"
-  Decoding instruction A64 2f300446
+  Decoding instruction A64 0x2f300446
   constant bits ( 128 ) Exp7__5 = __array _Z [ 2 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,16 }} ( replicate_bits.0 {{ 16,2 }} ( '0000000000010000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 6 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x2f380422"
-  Decoding instruction A64 2f380422
+  Decoding instruction A64 0x2f380422
   constant bits ( 128 ) Exp7__5 = __array _Z [ 1 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,8 }} ( replicate_bits.0 {{ 8,2 }} ( '00001000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 2 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x2f380445"
-  Decoding instruction A64 2f380445
+  Decoding instruction A64 0x2f380445
   constant bits ( 128 ) Exp7__5 = __array _Z [ 2 ] ;
   bits ( 64 ) result__4 ;
   result__4 = add_vec.0 {{ 2,32 }} ( '0000000000000000000000000000000000000000000000000000000000000000',trunc_vec.0 {{ 2,32,64 }} ( asr_vec.0 {{ 2,64 }} ( zcast_vec.0 {{ 2,64,32 }} ( Exp7__5 [ 0 +: 64 ],2,64 ),scast_vec.0 {{ 2,64,8 }} ( replicate_bits.0 {{ 8,2 }} ( '00001000',2 ),2,64 ),2 ),2,32 ),2 ) ;
   __array _Z [ 5 ] = ZeroExtend.0 {{ 64,128 }} ( result__4,128 ) ;
   "0x4cdf0860"
-  Decoding instruction A64 4cdf0860
+  Decoding instruction A64 0x4cdf0860
   __array _Z [ 0 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 0 ],0,32,Mem.read.0 {{ 4 }} ( __array _R [ 3 ],4,1 ) ) ;
   __array _Z [ 1 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 1 ],0,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000000000100' ),4,1 ) ) ;
   __array _Z [ 2 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 2 ],0,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000000001000' ),4,1 ) ) ;
@@ -147,7 +147,7 @@
   __array _Z [ 3 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 3 ],3,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000000111100' ),4,1 ) ) ;
   __array _R [ 3 ] = add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000001000000' ) ;
   "0x4cdf8000"
-  Decoding instruction A64 4cdf8000
+  Decoding instruction A64 0x4cdf8000
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],0,8,Mem.read.0 {{ 1 }} ( __array _R [ 0 ],1,1 ) ) ;
   __array _Z [ 1 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 1 ],0,8,Mem.read.0 {{ 1 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000000001' ),1,1 ) ) ;
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],1,8,Mem.read.0 {{ 1 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000000010' ),1,1 ) ) ;
@@ -182,7 +182,7 @@
   __array _Z [ 1 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 1 ],15,8,Mem.read.0 {{ 1 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000011111' ),1,1 ) ) ;
   __array _R [ 0 ] = add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000100000' ) ;
   "0x4cdf8800"
-  Decoding instruction A64 4cdf8800
+  Decoding instruction A64 0x4cdf8800
   __array _Z [ 0 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 0 ],0,32,Mem.read.0 {{ 4 }} ( __array _R [ 0 ],4,1 ) ) ;
   __array _Z [ 1 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 1 ],0,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000000100' ),4,1 ) ) ;
   __array _Z [ 0 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 0 ],1,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000001000' ),4,1 ) ) ;
@@ -193,22 +193,22 @@
   __array _Z [ 1 ] = Elem.set.0 {{ 128,32 }} ( __array _Z [ 1 ],3,32,Mem.read.0 {{ 4 }} ( add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000011100' ),4,1 ) ) ;
   __array _R [ 0 ] = add_bits.0 {{ 64 }} ( __array _R [ 0 ],'0000000000000000000000000000000000000000000000000000000000100000' ) ;
   "0x4d408660"
-  Decoding instruction A64 4d408660
+  Decoding instruction A64 0x4d408660
   __array _Z [ 0 ] = Elem.set.0 {{ 128,64 }} ( __array _Z [ 0 ],1,64,Mem.read.0 {{ 8 }} ( __array _R [ 19 ],8,1 ) ) ;
   "0x4e031c40"
-  Decoding instruction A64 4e031c40
+  Decoding instruction A64 0x4e031c40
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],1,8,__array _R [ 2 ] [ 0 +: 8 ] ) ;
   "0x4e040ea0"
-  Decoding instruction A64 4e040ea0
+  Decoding instruction A64 0x4e040ea0
   constant bits ( 64 ) Exp6__5 = __array _R [ 21 ] ;
   bits ( 128 ) result__4 ;
   result__4 = replicate_bits.0 {{ 32,4 }} ( Exp6__5 [ 0 +: 32 ],4 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x4e051ce0"
-  Decoding instruction A64 4e051ce0
+  Decoding instruction A64 0x4e051ce0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],2,8,__array _R [ 7 ] [ 0 +: 8 ] ) ;
   "0x4e052042"
-  Decoding instruction A64 4e052042
+  Decoding instruction A64 0x4e052042
   bits ( 128 ) result__4 ;
   constant bits ( 256 ) Cse0__5 = append_bits.0 {{ 128,128 }} ( __array _Z [ 3 ],__array _Z [ 2 ] ) ;
   result__4 = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' ;
@@ -262,34 +262,34 @@
   }
   __array _Z [ 2 ] = result__4 ;
   "0x4e071c00"
-  Decoding instruction A64 4e071c00
+  Decoding instruction A64 0x4e071c00
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],3,8,__array _R [ 0 ] [ 0 +: 8 ] ) ;
   "0x4e071cc0"
-  Decoding instruction A64 4e071cc0
+  Decoding instruction A64 0x4e071cc0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],3,8,__array _R [ 6 ] [ 0 +: 8 ] ) ;
   "0x4e080401"
-  Decoding instruction A64 4e080401
+  Decoding instruction A64 0x4e080401
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = replicate_bits.0 {{ 64,2 }} ( Elem.read.0 {{ 64,64 }} ( Exp7__5 [ 0 +: 64 ],0,64 ),2 ) ;
   __array _Z [ 1 ] = result__4 ;
   "0x4e091ca0"
-  Decoding instruction A64 4e091ca0
+  Decoding instruction A64 0x4e091ca0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],4,8,__array _R [ 5 ] [ 0 +: 8 ] ) ;
   "0x4e0b1c80"
-  Decoding instruction A64 4e0b1c80
+  Decoding instruction A64 0x4e0b1c80
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],5,8,__array _R [ 4 ] [ 0 +: 8 ] ) ;
   "0x4e0d1c40"
-  Decoding instruction A64 4e0d1c40
+  Decoding instruction A64 0x4e0d1c40
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],6,8,__array _R [ 2 ] [ 0 +: 8 ] ) ;
   "0x4e0f1c60"
-  Decoding instruction A64 4e0f1c60
+  Decoding instruction A64 0x4e0f1c60
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],7,8,__array _R [ 3 ] [ 0 +: 8 ] ) ;
   "0x4e211ca1"
-  Decoding instruction A64 4e211ca1
+  Decoding instruction A64 0x4e211ca1
   __array _Z [ 1 ] = and_bits.0 {{ 128 }} ( __array _Z [ 5 ],__array _Z [ 1 ] ) ;
   "0x4e61d800"
-  Decoding instruction A64 4e61d800
+  Decoding instruction A64 0x4e61d800
   bits ( 128 ) result__4 ;
   bits ( 4 ) FPDecodeRounding9__6 ;
   FPDecodeRounding9__6 = ZeroExtend.0 {{ 2,4 }} ( FPCR [ 22 +: 2 ],4 ) ;
@@ -297,7 +297,7 @@
   constant bits ( 64 ) Exp13__5 = FixedToFP.0 {{ 64,64 }} ( Elem.read.0 {{ 128,64 }} ( __array _Z [ 0 ],1,64 ),0,FALSE,FPCR,cvt_bits_uint.0 {{ 4 }} ( FPDecodeRounding9__6 ) ) ;
   __array _Z [ 0 ] = Elem.set.0 {{ 128,64 }} ( Elem.set.0 {{ 128,64 }} ( result__4,0,64,Exp12__5 ),1,64,Exp13__5 ) ;
   "0x4e61d821"
-  Decoding instruction A64 4e61d821
+  Decoding instruction A64 0x4e61d821
   bits ( 128 ) result__4 ;
   bits ( 4 ) FPDecodeRounding9__6 ;
   FPDecodeRounding9__6 = ZeroExtend.0 {{ 2,4 }} ( FPCR [ 22 +: 2 ],4 ) ;
@@ -305,7 +305,7 @@
   constant bits ( 64 ) Exp13__5 = FixedToFP.0 {{ 64,64 }} ( Elem.read.0 {{ 128,64 }} ( __array _Z [ 1 ],1,64 ),0,FALSE,FPCR,cvt_bits_uint.0 {{ 4 }} ( FPDecodeRounding9__6 ) ) ;
   __array _Z [ 1 ] = Elem.set.0 {{ 128,64 }} ( Elem.set.0 {{ 128,64 }} ( result__4,0,64,Exp12__5 ),1,64,Exp13__5 ) ;
   "0x4e61d842"
-  Decoding instruction A64 4e61d842
+  Decoding instruction A64 0x4e61d842
   bits ( 128 ) result__4 ;
   bits ( 4 ) FPDecodeRounding9__6 ;
   FPDecodeRounding9__6 = ZeroExtend.0 {{ 2,4 }} ( FPCR [ 22 +: 2 ],4 ) ;
@@ -313,7 +313,7 @@
   constant bits ( 64 ) Exp13__5 = FixedToFP.0 {{ 64,64 }} ( Elem.read.0 {{ 128,64 }} ( __array _Z [ 2 ],1,64 ),0,FALSE,FPCR,cvt_bits_uint.0 {{ 4 }} ( FPDecodeRounding9__6 ) ) ;
   __array _Z [ 2 ] = Elem.set.0 {{ 128,64 }} ( Elem.set.0 {{ 128,64 }} ( result__4,0,64,Exp12__5 ),1,64,Exp13__5 ) ;
   "0x4e61d863"
-  Decoding instruction A64 4e61d863
+  Decoding instruction A64 0x4e61d863
   bits ( 128 ) result__4 ;
   bits ( 4 ) FPDecodeRounding9__6 ;
   FPDecodeRounding9__6 = ZeroExtend.0 {{ 2,4 }} ( FPCR [ 22 +: 2 ],4 ) ;
@@ -321,168 +321,168 @@
   constant bits ( 64 ) Exp13__5 = FixedToFP.0 {{ 64,64 }} ( Elem.read.0 {{ 128,64 }} ( __array _Z [ 3 ],1,64 ),0,FALSE,FPCR,cvt_bits_uint.0 {{ 4 }} ( FPDecodeRounding9__6 ) ) ;
   __array _Z [ 3 ] = Elem.set.0 {{ 128,64 }} ( Elem.set.0 {{ 128,64 }} ( result__4,0,64,Exp12__5 ),1,64,Exp13__5 ) ;
   "0x4ea11c23"
-  Decoding instruction A64 4ea11c23
+  Decoding instruction A64 0x4ea11c23
   __array _Z [ 3 ] = or_bits.0 {{ 128 }} ( __array _Z [ 1 ],__array _Z [ 1 ] ) ;
   "0x4ea28400"
-  Decoding instruction A64 4ea28400
+  Decoding instruction A64 0x4ea28400
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 2 ] ;
   bits ( 128 ) result__4 ;
   result__4 = add_vec.0 {{ 4,32 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ],4 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x4ee08484"
-  Decoding instruction A64 4ee08484
+  Decoding instruction A64 0x4ee08484
   constant bits ( 128 ) Exp7__5 = __array _Z [ 4 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = add_vec.0 {{ 2,64 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ],2 ) ;
   __array _Z [ 4 ] = result__4 ;
   "0x4ee08c00"
-  Decoding instruction A64 4ee08c00
+  Decoding instruction A64 0x4ee08c00
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = ite_vec.0 {{ 2,64 }} ( select_vec.0 {{ 2,2,1 }} ( not_bits.0 {{ 2 }} ( eq_vec.0 {{ 2,64 }} ( and_bits.0 {{ 128 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ] ),replicate_bits.0 {{ 64,2 }} ( '0000000000000000000000000000000000000000000000000000000000000000',2 ),2 ) ),'0000000000000000000000000000000100000000000000000000000000000000' ),replicate_bits.0 {{ 64,2 }} ( '1111111111111111111111111111111111111111111111111111111111111111',2 ),replicate_bits.0 {{ 64,2 }} ( '0000000000000000000000000000000000000000000000000000000000000000',2 ),2 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x4ee28420"
-  Decoding instruction A64 4ee28420
+  Decoding instruction A64 0x4ee28420
   constant bits ( 128 ) Exp7__5 = __array _Z [ 1 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 2 ] ;
   bits ( 128 ) result__4 ;
   result__4 = add_vec.0 {{ 2,64 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ],2 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x4f000400"
-  Decoding instruction A64 4f000400
+  Decoding instruction A64 0x4f000400
   __array _Z [ 0 ] = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' ;
   "0x4f000401"
-  Decoding instruction A64 4f000401
+  Decoding instruction A64 0x4f000401
   __array _Z [ 1 ] = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' ;
   "0x4f000404"
-  Decoding instruction A64 4f000404
+  Decoding instruction A64 0x4f000404
   __array _Z [ 4 ] = '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000' ;
   "0x4f0004e6"
-  Decoding instruction A64 4f0004e6
+  Decoding instruction A64 0x4f0004e6
   __array _Z [ 6 ] = '00000000000000000000000000000111000000000000000000000000000001110000000000000000000000000000011100000000000000000000000000000111' ;
   "0x4f01e6c0"
-  Decoding instruction A64 4f01e6c0
+  Decoding instruction A64 0x4f01e6c0
   __array _Z [ 0 ] = '00110110001101100011011000110110001101100011011000110110001101100011011000110110001101100011011000110110001101100011011000110110' ;
   "0x4f02e780"
-  Decoding instruction A64 4f02e780
+  Decoding instruction A64 0x4f02e780
   __array _Z [ 0 ] = '01011100010111000101110001011100010111000101110001011100010111000101110001011100010111000101110001011100010111000101110001011100' ;
   "0x4f20a400"
-  Decoding instruction A64 4f20a400
+  Decoding instruction A64 0x4f20a400
   constant bits ( 128 ) Exp9__6 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = scast_vec.0 {{ 2,64,32 }} ( Exp9__6 [ 64 +: 64 ],2,64 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x4f20a401"
-  Decoding instruction A64 4f20a401
+  Decoding instruction A64 0x4f20a401
   constant bits ( 128 ) Exp9__6 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = scast_vec.0 {{ 2,64,32 }} ( Exp9__6 [ 64 +: 64 ],2,64 ) ;
   __array _Z [ 1 ] = result__4 ;
   "0x4f20a421"
-  Decoding instruction A64 4f20a421
+  Decoding instruction A64 0x4f20a421
   constant bits ( 128 ) Exp9__6 = __array _Z [ 1 ] ;
   bits ( 128 ) result__4 ;
   result__4 = scast_vec.0 {{ 2,64,32 }} ( Exp9__6 [ 64 +: 64 ],2,64 ) ;
   __array _Z [ 1 ] = result__4 ;
   "0x5ef1b820"
-  Decoding instruction A64 5ef1b820
+  Decoding instruction A64 0x5ef1b820
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( add_bits.0 {{ 64 }} ( __array _Z [ 1 ] [ 0 +: 64 ],__array _Z [ 1 ] [ 64 +: 64 ] ),128 ) ;
   "0x5ef1b880"
-  Decoding instruction A64 5ef1b880
+  Decoding instruction A64 0x5ef1b880
   __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( add_bits.0 {{ 64 }} ( __array _Z [ 4 ] [ 0 +: 64 ],__array _Z [ 4 ] [ 64 +: 64 ] ),128 ) ;
   "0x6e030460"
-  Decoding instruction A64 6e030460
+  Decoding instruction A64 0x6e030460
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],1,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 3 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0304c0"
-  Decoding instruction A64 6e0304c0
+  Decoding instruction A64 0x6e0304c0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],1,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 6 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e050440"
-  Decoding instruction A64 6e050440
+  Decoding instruction A64 0x6e050440
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],2,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 2 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0504a0"
-  Decoding instruction A64 6e0504a0
+  Decoding instruction A64 0x6e0504a0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],2,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 5 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e070420"
-  Decoding instruction A64 6e070420
+  Decoding instruction A64 0x6e070420
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],3,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e090480"
-  Decoding instruction A64 6e090480
+  Decoding instruction A64 0x6e090480
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],4,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 4 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e090680"
-  Decoding instruction A64 6e090680
+  Decoding instruction A64 0x6e090680
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],4,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 20 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0b0460"
-  Decoding instruction A64 6e0b0460
+  Decoding instruction A64 0x6e0b0460
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],5,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 3 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0b0660"
-  Decoding instruction A64 6e0b0660
+  Decoding instruction A64 0x6e0b0660
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],5,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 19 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0d0440"
-  Decoding instruction A64 6e0d0440
+  Decoding instruction A64 0x6e0d0440
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],6,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 2 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0d0640"
-  Decoding instruction A64 6e0d0640
+  Decoding instruction A64 0x6e0d0640
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],6,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 18 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0f0420"
-  Decoding instruction A64 6e0f0420
+  Decoding instruction A64 0x6e0f0420
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],7,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e0f0620"
-  Decoding instruction A64 6e0f0620
+  Decoding instruction A64 0x6e0f0620
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],7,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 17 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e110600"
-  Decoding instruction A64 6e110600
+  Decoding instruction A64 0x6e110600
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],8,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 16 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1304e0"
-  Decoding instruction A64 6e1304e0
+  Decoding instruction A64 0x6e1304e0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],9,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 7 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1504c0"
-  Decoding instruction A64 6e1504c0
+  Decoding instruction A64 0x6e1504c0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],10,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 6 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1704a0"
-  Decoding instruction A64 6e1704a0
+  Decoding instruction A64 0x6e1704a0
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],11,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 5 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e190480"
-  Decoding instruction A64 6e190480
+  Decoding instruction A64 0x6e190480
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],12,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 4 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1b0460"
-  Decoding instruction A64 6e1b0460
+  Decoding instruction A64 0x6e1b0460
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],13,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 3 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1d0440"
-  Decoding instruction A64 6e1d0440
+  Decoding instruction A64 0x6e1d0440
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],14,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 2 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e1f0420"
-  Decoding instruction A64 6e1f0420
+  Decoding instruction A64 0x6e1f0420
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( __array _Z [ 0 ],15,8,Elem.read.0 {{ 64,8 }} ( __array _Z [ 1 ] [ 0 +: 64 ],0,8 ) ) ;
   "0x6e200800"
-  Decoding instruction A64 6e200800
+  Decoding instruction A64 0x6e200800
   bits ( 128 ) result__4 ;
   __array _Z [ 0 ] = Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( Elem.set.0 {{ 128,8 }} ( result__4,3,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],0,8 ) ),2,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],1,8 ) ),1,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],2,8 ) ),0,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],3,8 ) ),7,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],4,8 ) ),6,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],5,8 ) ),5,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],6,8 ) ),4,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],7,8 ) ),11,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],8,8 ) ),10,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],9,8 ) ),9,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],10,8 ) ),8,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],11,8 ) ),15,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],12,8 ) ),14,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],13,8 ) ),13,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],14,8 ) ),12,8,Elem.read.0 {{ 128,8 }} ( __array _Z [ 0 ],15,8 ) ) ;
   "0x6e205800"
-  Decoding instruction A64 6e205800
+  Decoding instruction A64 0x6e205800
   constant bits ( 128 ) Exp4__5 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = select_vec.0 {{ 16,16,8 }} ( not_bits.0 {{ 128 }} ( Exp4__5 [ 0 +: 128 ] ),'00000000000000000000000000001111000000000000000000000000000011100000000000000000000000000000110100000000000000000000000000001100000000000000000000000000000010110000000000000000000000000000101000000000000000000000000000001001000000000000000000000000000010000000000000000000000000000000011100000000000000000000000000000110000000000000000000000000000001010000000000000000000000000000010000000000000000000000000000000011000000000000000000000000000000100000000000000000000000000000000100000000000000000000000000000000' ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x6e211c00"
-  Decoding instruction A64 6e211c00
+  Decoding instruction A64 0x6e211c00
   __array _Z [ 0 ] = eor_bits.0 {{ 128 }} ( __array _Z [ 1 ],eor_bits.0 {{ 128 }} ( '00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000',__array _Z [ 0 ] ) ) ;
   "0x6ea68c00"
-  Decoding instruction A64 6ea68c00
+  Decoding instruction A64 0x6ea68c00
   constant bits ( 128 ) Exp7__5 = __array _Z [ 0 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 6 ] ;
   bits ( 128 ) result__4 ;
   result__4 = ite_vec.0 {{ 4,32 }} ( eq_vec.0 {{ 4,32 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ],4 ),replicate_bits.0 {{ 32,4 }} ( '11111111111111111111111111111111',4 ),replicate_bits.0 {{ 32,4 }} ( '00000000000000000000000000000000',4 ),4 ) ;
   __array _Z [ 0 ] = result__4 ;
   "0x6ee08421"
-  Decoding instruction A64 6ee08421
+  Decoding instruction A64 0x6ee08421
   constant bits ( 128 ) Exp7__5 = __array _Z [ 1 ] ;
   constant bits ( 128 ) Exp9__5 = __array _Z [ 0 ] ;
   bits ( 128 ) result__4 ;
   result__4 = sub_vec.0 {{ 2,64 }} ( Exp7__5 [ 0 +: 128 ],Exp9__5 [ 0 +: 128 ],2 ) ;
   __array _Z [ 1 ] = result__4 ;
   "0x6f000400"
-  Decoding instruction A64 6f000400
+  Decoding instruction A64 0x6f000400
   __array _Z [ 0 ] = '11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111' ;

--- a/tests/aslt/test_dis.t
+++ b/tests/aslt/test_dis.t
@@ -6,7 +6,7 @@ run asli with these commands
   "
   0xab030041
   "
-  Decoding instruction A64 ab030041
+  Decoding instruction A64 0xab030041
   constant bits ( 64 ) Cse0__5 = add_bits.0 {{ 64 }} ( __array _R [ 2 ],__array _R [ 3 ] ) ;
   PSTATE . V = not_bits.0 {{ 1 }} ( cvt_bool_bv.0 {{  }} ( eq_bits.0 {{ 128 }} ( SignExtend.0 {{ 64,128 }} ( Cse0__5,128 ),add_bits.0 {{ 128 }} ( SignExtend.0 {{ 64,128 }} ( __array _R [ 2 ],128 ),SignExtend.0 {{ 64,128 }} ( __array _R [ 3 ],128 ) ) ) ) ) ;
   PSTATE . C = not_bits.0 {{ 1 }} ( cvt_bool_bv.0 {{  }} ( eq_bits.0 {{ 128 }} ( ZeroExtend.0 {{ 64,128 }} ( Cse0__5,128 ),add_bits.0 {{ 128 }} ( ZeroExtend.0 {{ 64,128 }} ( __array _R [ 2 ],128 ),ZeroExtend.0 {{ 64,128 }} ( __array _R [ 3 ],128 ) ) ) ) ) ;
@@ -23,14 +23,14 @@ run asli with these commands
   "
   0xd10083ff
   "
-  Decoding instruction A64 d10083ff
+  Decoding instruction A64 0xd10083ff
   SP_EL0 = add_bits.0 {{ 64 }} ( SP_EL0,'1111111111111111111111111111111111111111111111111111111111100000' ) ;
   ""
   Stmt_Assign(LExpr_Var("SP_EL0"),Expr_TApply("add_bits.0",[64],[Expr_Var("SP_EL0");'1111111111111111111111111111111111111111111111111111111111100000']))
   "
   0xa8c80861
   "
-  Decoding instruction A64 a8c80861
+  Decoding instruction A64 0xa8c80861
   __array _R [ 1 ] = Mem.read.0 {{ 8 }} ( __array _R [ 3 ],8,0 ) ;
   __array _R [ 2 ] = Mem.read.0 {{ 8 }} ( add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000000001000' ),8,0 ) ;
   __array _R [ 3 ] = add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000010000000' ) ;
@@ -41,7 +41,7 @@ run asli with these commands
   "
   0xa8880861
   "
-  Decoding instruction A64 a8880861
+  Decoding instruction A64 0xa8880861
   Mem.set.0 {{ 8 }} ( __array _R [ 3 ],8,0,__array _R [ 1 ] ) ;
   Mem.set.0 {{ 8 }} ( add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000000001000' ),8,0,__array _R [ 2 ] ) ;
   __array _R [ 3 ] = add_bits.0 {{ 64 }} ( __array _R [ 3 ],'0000000000000000000000000000000000000000000000000000000010000000' ) ;
@@ -52,7 +52,7 @@ run asli with these commands
   "
   0x1e630040
   "
-  Decoding instruction A64 1e630040
+  Decoding instruction A64 0x1e630040
   bits ( 4 ) FPDecodeRounding5__5 ;
   FPDecodeRounding5__5 = ZeroExtend.0 {{ 2,4 }} ( FPCR [ 22 +: 2 ],4 ) ;
   constant bits ( 64 ) Exp9__5 = FixedToFP.0 {{ 32,64 }} ( __array _R [ 2 ] [ 0 +: 32 ],0,TRUE,FPCR,cvt_bits_uint.0 {{ 4 }} ( FPDecodeRounding5__5 ) ) ;
@@ -65,14 +65,14 @@ run asli with these commands
   "
   0xd53b4200
   "
-  Decoding instruction A64 d53b4200
+  Decoding instruction A64 0xd53b4200
   __array _R [ 0 ] = append_bits.0 {{ 36,28 }} ( ZeroExtend.0 {{ 4,36 }} ( append_bits.0 {{ 3,1 }} ( append_bits.0 {{ 2,1 }} ( append_bits.0 {{ 1,1 }} ( PSTATE . N,PSTATE . Z ),PSTATE . C ),PSTATE . V ),36 ),'0000000000000000000000000000' ) ;
   ""
   Stmt_Assign(LExpr_Array(LExpr_Var("_R"),0),Expr_TApply("append_bits.0",[36;28],[Expr_TApply("ZeroExtend.0",[4;36],[Expr_TApply("append_bits.0",[3;1],[Expr_TApply("append_bits.0",[2;1],[Expr_TApply("append_bits.0",[1;1],[Expr_Field(Expr_Var("PSTATE"),"N");Expr_Field(Expr_Var("PSTATE"),"Z")]);Expr_Field(Expr_Var("PSTATE"),"C")]);Expr_Field(Expr_Var("PSTATE"),"V")]);36]);'0000000000000000000000000000']))
   "
   0x0e000000
   "
-  Decoding instruction A64 e000000
+  Decoding instruction A64 0x0e000000
   constant bits ( 16 ) Cse15__5 = ZeroExtend.0 {{ 8,16 }} ( __array _Z [ 0 ] [ 0 +: 8 ],16 ) ;
   constant bits ( 16 ) Cse14__5 = mul_bits.0 {{ 16 }} ( ZeroExtend.0 {{ 8,16 }} ( __array _Z [ 0 ] [ 0 +: 8 ],16 ),'0000000000001000' ) ;
   constant bits ( 16 ) Cse13__5 = ZeroExtend.0 {{ 8,16 }} ( __array _Z [ 0 ] [ 8 +: 8 ],16 ) ;
@@ -179,7 +179,7 @@ run asli with these commands
   "
   0x0e205800
   "
-  Decoding instruction A64 e205800
+  Decoding instruction A64 0x0e205800
   bits ( 4 ) result__5 = '0000' ;
   if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 0 +: 1 ],'1' ) then {
   result__5 = '0001' ;
@@ -586,7 +586,7 @@ run asli with these commands
   "
   0x4f71d000
   "
-  Decoding instruction A64 4f71d000
+  Decoding instruction A64 0x4f71d000
   constant bits ( 32 ) Cse43__5 = SignExtend.0 {{ 16,32 }} ( __array _Z [ 0 ] [ 0 +: 16 ],32 ) ;
   constant bits ( 32 ) Cse36__5 = SignExtend.0 {{ 16,32 }} ( __array _Z [ 0 ] [ 16 +: 16 ],32 ) ;
   constant bits ( 32 ) Cse30__5 = SignExtend.0 {{ 16,32 }} ( __array _Z [ 0 ] [ 32 +: 16 ],32 ) ;

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -82,7 +82,7 @@ let test_compare env () : unit =
 
                 (try
                     (* Generate and evaluate partially evaluated instruction *)
-                    let disStmts = Dis.dis_decode_entry disEnv lenv decoder op in
+                    let disStmts = Dis.dis_decode_entry disEnv lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
                     List.iter (Eval.eval_stmt disEvalEnv) disStmts;
 
                     compare_env evalEnv disEvalEnv opcode


### PR DESCRIPTION
Experimental support for symbolic opcodes in ASLp.

Opcode semantics generation now accepts an "opcode" template, for example:

```
ASLi> :sem A64 0x122:9|sh:1|imm:12|0xa4:10
Decoding instruction A64 0x122:9|sh:1|imm:12|0xa4:10
bits ( 64 ) imm__3 ;
if eq_bits.0 {{ 1 }} ( sh [ 0 +: 1 ],'0' ) then {
imm__3 = ZeroExtend.0 {{ 12,64 }} ( imm [ 0 +: 12 ],64 ) ;
}  else {
if eq_bits.0 {{ 1 }} ( sh [ 0 +: 1 ],'1' ) then {
imm__3 = ZeroExtend.0 {{ 24,64 }} ( append_bits.0 {{ 12,12 }} ( imm [ 0 +: 12 ],'000000000000' ),64 ) ;
}  else {
assert FALSE ;
}
}
__array _R [ 4 ] = add_bits.0 {{ 64 }} ( __array _R [ 5 ],imm__3 ) ;
```
