### PR TITLE
fix symbolic field handling by `CommonSubExprElim`

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -135,7 +135,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
 
                     (try
                         (* Generate and evaluate partially evaluated instruction *)
-                        let disStmts = Dis.dis_decode_entry disEnv lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
+                        let disStmts = Dis.dis_decode_entry disEnv lenv decoder (sym_bits_of_bv (Primops.prim_cvt_int_bits (Z.of_int 32) op)) in
                         List.iter (eval_stmt disEvalEnv) disStmts;
 
                         if Eval.Env.compare evalEnv disEvalEnv then
@@ -193,7 +193,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         Printf.printf "Decoding instruction %s %s\n" iset opcode;
         cpu'.sem iset opcode
     | ":ast" :: iset :: opcode :: rest when List.length rest <= 1 ->
-        let op = sym_of_sym_bits (sym_bits_of_string opcode) in
+        let op = sym_bits_of_string opcode in
         let decoder = Eval.Env.getDecoder cpu.env (Ident iset) in
         let chan_opt = Option.map open_out (List.nth_opt rest 0) in
         let chan = Option.value chan_opt ~default:stdout in
@@ -230,7 +230,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         let cpu' = Cpu.mkCPU (Eval.Env.copy cpu.env) cpu.denv in
         let op = Z.of_string opcode in
         let decoder = Eval.Env.getDecoder cpu'.env (Ident iset) in
-        let stmts = Dis.dis_decode_entry cpu'.env cpu.denv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
+        let stmts = Dis.dis_decode_entry cpu'.env cpu.denv decoder (sym_bits_of_bv (Primops.prim_cvt_int_bits (Z.of_int 32) op)) in
         let chan = open_out_bin fname in
         Printf.printf "Dumping instruction semantics for %s %s" iset (Z.format "%x" op);
         Printf.printf " to file %s\n" fname;

--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -193,7 +193,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         Printf.printf "Decoding instruction %s %s\n" iset opcode;
         cpu'.sem iset opcode
     | ":ast" :: iset :: opcode :: rest when List.length rest <= 1 ->
-        let (op, _) = sym_bits_of_string opcode in
+        let op = sym_of_sym_bits (sym_bits_of_string opcode) in
         let decoder = Eval.Env.getDecoder cpu.env (Ident iset) in
         let chan_opt = Option.map open_out (List.nth_opt rest 0) in
         let chan = Option.value chan_opt ~default:stdout in

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -25,7 +25,7 @@ let eval_instr (opcode: string) : string * string =
     let env' = Lazy.force persistent_env in
     let lenv = Dis.build_env env' in
     let decoder = Eval.Env.getDecoder env' (Ident "A64") in
-    let op = sym_of_sym_bits (sym_bits_of_string opcode) in
+    let op = sym_bits_of_string opcode in
     let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder op in
 
     let stmts'   = List.map pp_raw stmts in

--- a/bin/server.ml
+++ b/bin/server.ml
@@ -25,7 +25,7 @@ let eval_instr (opcode: string) : string * string =
     let env' = Lazy.force persistent_env in
     let lenv = Dis.build_env env' in
     let decoder = Eval.Env.getDecoder env' (Ident "A64") in
-    let (op, _) = sym_bits_of_string opcode in
+    let op = sym_of_sym_bits (sym_bits_of_string opcode) in
     let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder op in
 
     let stmts'   = List.map pp_raw stmts in

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -58,7 +58,12 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
 
     and sem (iset: string) (opcode: string): unit =
         let decoder = Eval.Env.getDecoder env (Ident iset) in
+
+        (* Parse symbolic opcode *)
         let (op, _) = sym_bits_of_string opcode in
+
+        let (lenv, globals) = denv in
+        
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))
             (Dis.dis_decode_entry env denv decoder op)

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -60,7 +60,7 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         let decoder = Eval.Env.getDecoder env (Ident iset) in
 
         (* Parse symbolic opcode *)
-        let op = sym_of_sym_bits (sym_bits_of_string opcode) in
+        let op = sym_bits_of_string opcode in
         
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -60,9 +60,7 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         let decoder = Eval.Env.getDecoder env (Ident iset) in
 
         (* Parse symbolic opcode *)
-        let (op, _) = sym_bits_of_string opcode in
-
-        let (lenv, globals) = denv in
+        let op = sym_of_sym_bits (sym_bits_of_string opcode) in
         
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -970,6 +970,9 @@ let segment_of_string (s: string): segment =
 let sym_bits_of_string (s: string): sym_bits =
   List.map segment_of_string (String.split_on_char '|' s)
 
+let sym_bits_of_bv (bv: Primops.bitvector): sym_bits =
+  [SegmentBits bv]
+
 let sym_of_segment (s: segment): sym =
   match s with
   | SegmentBits b -> Val (VBits b)

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -381,7 +381,7 @@ let op_dis (env: Env.t) (iset: string) (op: Primops.bigint): stmt list opresult 
   let lenv = Dis.build_env env in
   let decoder = Eval.Env.getDecoder env (Ident iset) in
   try
-    let stmts = Dis.dis_decode_entry env lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
+    let stmts = Dis.dis_decode_entry env lenv decoder (sym_bits_of_bv (Primops.prim_cvt_int_bits (Z.of_int 32) op)) in
     Result.Ok stmts
   with
     | e -> Result.Error (Op_DisFail e)

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -82,7 +82,7 @@ let test_compare env () : unit =
 
                 (try
                     (* Generate and evaluate partially evaluated instruction *)
-                    let disStmts = Dis.dis_decode_entry disEnv lenv decoder (Val (Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op))) in
+                    let disStmts = Dis.dis_decode_entry disEnv lenv decoder (Symbolic.sym_bits_of_bv (Primops.prim_cvt_int_bits (Z.of_int 32) op)) in
                     List.iter (Eval.eval_stmt disEvalEnv) disStmts;
 
                     compare_env evalEnv disEvalEnv opcode


### PR DESCRIPTION
Fix a problem with the treatment of symbolic field variables by common-subexpression-elimination.

When a common subexpression has been identified, it needs to place it in the statement list. It does this by placing it in the first position after all its dependencies have been assigned. The problem comes because a common subexpression that depends on a symbolic field won't ever find an assignment to the symbolic field.

This is what the algorithm was probably supposed to do, but as they explain in a comment what they actually do is place the definition of the common subexpression in the first place after all its dependencies have _appeared_ (whether assigned to or not). Therefore in practice, common expressions involving symbolic fields would end up placed after their first use.

This PR fixes it by:

* Passing a list of globals into CSE which are treated as predefined
* Appending symbolic fields to the global identifier set
