### PR TITLE
rotates as primitives

### DIFF
--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -108,11 +108,11 @@ let no_inline = [
 ]
 
 let no_inline_pure () = [
-  "ROR",0;
-  "ROL",0;
   "LSL",0;
   "LSR",0;
   "ASR",0;
+  "ROR",0;
+  "ROL",0;
   "SignExtend",0;
   "ZeroExtend",0;
 ] @ (if !Symbolic.use_vectoriser then [

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -108,6 +108,8 @@ let no_inline = [
 ]
 
 let no_inline_pure () = [
+  "ROR",0;
+  "ROL",0;
   "LSL",0;
   "LSR",0;
   "ASR",0;

--- a/libASL/dis_tc.ml
+++ b/libASL/dis_tc.ml
@@ -91,6 +91,8 @@ let prim_type fi targs =
   | ("lsl_bits",          [     n])     -> Some (Type_Bits n)
   | ("lsr_bits",          [     n])     -> Some (Type_Bits n)
   | ("asr_bits",          [     n])     -> Some (Type_Bits n)
+  | ("ror_bits",          [     n])     -> Some (Type_Bits n)
+  | ("rol_bits",          [     n])     -> Some (Type_Bits n)
   | ("sle_bits",          [     n])     -> Some (Symbolic.type_bool)
   | ("slt_bits",          [     n])     -> Some (Symbolic.type_bool)
 

--- a/libASL/offline_transform.ml
+++ b/libASL/offline_transform.ml
@@ -179,6 +179,8 @@ let pure_prims =
     "sle_bits";
     "lsl_bits";
     "asr_bits";
+    "ror_bits";
+    "rol_bits";
     "slt_bits";
     "sdiv_bits";
   ]
@@ -925,4 +927,3 @@ let gen_prog fns results env =
 let run fns env =
   let (taint_res, callers) = analysis fns env in
   gen_prog fns taint_res env
-

--- a/libASL/scala_backend.ml
+++ b/libASL/scala_backend.ml
@@ -57,7 +57,7 @@ module StringSet = Set.Make(String)
         "f_gen_eq_bits"; "f_gen_eq_enum"; "f_gen_int_lit"; "f_gen_store";
         "f_gen_load"; "f_gen_SignExtend"; "f_gen_ZeroExtend"; "f_gen_add_bits";
         "f_gen_and_bits"; "f_gen_and_bool"; "f_gen_asr_bits"; "f_gen_lsl_bits";
-        "f_gen_lsr_bits"; "f_gen_mul_bits"; "f_gen_ne_bits"; "f_gen_not_bits";
+        "f_gen_lsr_bits"; "f_gen_ror_bits"; "f_gen_rol_bits"; "f_gen_mul_bits"; "f_gen_ne_bits"; "f_gen_not_bits";
         "f_gen_not_bool"; "f_gen_or_bits"; "f_gen_or_bool"; "f_gen_sdiv_bits";
         "f_gen_sle_bits"; "f_gen_slt_bits"; "f_gen_sub_bits";
         "f_gen_AArch64_MemTag_set"; "f_gen_Mem_read"; "f_gen_slice";

--- a/libASL/scala_backend.ml
+++ b/libASL/scala_backend.ml
@@ -42,7 +42,7 @@ module StringSet = Set.Make(String)
         "f_mul_bits"; "f_and_bits"; "f_or_bits"; "f_eor_bits"; "f_not_bits";
         "f_slt_bits"; "f_sle_bits"; "f_zeros_bits"; "f_ones_bits";
         "f_ZeroExtend"; "f_SignExtend"; "f_asr_bits"; "f_lsl_bits";
-        "f_lsr_bits"; "f_decl_bool"; "f_decl_bv"; "f_AtomicEnd";
+        "f_lsr_bits"; "f_ror_bits"; "f_rol_bits"; "f_decl_bool"; "f_decl_bv"; "f_AtomicEnd";
         "f_AtomicStart"; "f_replicate_bits"; "f_append_bits"; "f_gen_BFAdd";
         "f_gen_BFMul"; "f_gen_FPAdd"; "f_gen_FPCompare"; "f_gen_FPCompareEQ";
         "f_gen_FPCompareGE"; "f_gen_FPCompareGT"; "f_gen_FPConvert";
@@ -843,4 +843,3 @@ let run (dfn : ident) (dfnsig : ty option * 'a * ident list * ident list * 'b * 
   let files = (write_test_file tests dir st)::files in
   write_decoder_file dfn (lift_fsig dfnsig) files dir st |> ignore ; 
   ()
-

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -15,6 +15,8 @@ let pure_prims =
     FIdent("asr_bits",0);
     FIdent("lsr_bits",0);
     FIdent("lsl_bits",0);
+    FIdent("ror_bits",0);
+    FIdent("rol_bits",0);
     FIdent("slt_bits",0);
     FIdent("sle_bits",0);
   ]
@@ -113,6 +115,8 @@ let infer_type (e: expr): ty option =
     | "lsr_bits"           -> Some(Type_Bits(num1))
     | "asl_bits"           -> Some(Type_Bits(num1))
     | "asr_bits"           -> Some(Type_Bits(num1))
+    | "ror_bits"           -> Some(Type_Bits(num1))
+    | "rol_bits"           -> Some(Type_Bits(num1))
     | "append_bits"        ->
       Some(Type_Bits(Expr_LitInt(string_of_int((int_of_string v1) + (int_of_string v2)))))
     | _ -> None
@@ -636,6 +640,12 @@ module StatefulIntToBits = struct
       | Expr_TApply (FIdent ("ASR", 0), [size], [x; n]) ->
           let (n,w) = force_signed (bv_of_int_expr st n) in
           expr_prim' "asr_bits" [size; expr_of_abs w] [x;sym_expr n]
+      | Expr_TApply (FIdent ("ROR", 0), [size], [x; n]) ->
+          let (n,w) = force_signed (bv_of_int_expr st n) in
+          expr_prim' "ror_bits" [size; expr_of_abs w] [x;sym_expr n]
+      | Expr_TApply (FIdent ("ROL", 0), [size], [x; n]) ->
+          let (n,w) = force_signed (bv_of_int_expr st n) in
+          expr_prim' "rol_bits" [size; expr_of_abs w] [x;sym_expr n]
 
       | e -> e
       in
@@ -901,6 +911,8 @@ module IntToBits = struct
       | FIdent ("lsl_bits", 0), [Expr_LitInt n; _], _
       | FIdent ("lsr_bits", 0), [Expr_LitInt n; _], _
       | FIdent ("asr_bits", 0), [Expr_LitInt n; _], _
+      | FIdent ("ror_bits", 0), [Expr_LitInt n; _], _
+      | FIdent ("rol_bits", 0), [Expr_LitInt n; _], _
       | FIdent ("ones_bits", 0), [Expr_LitInt n], _ -> int_of_string n
       | FIdent ("append_bits", 0), [Expr_LitInt n; Expr_LitInt m], _ -> int_of_string n + int_of_string m
       | FIdent ("replicate_bits", 0), [Expr_LitInt n; Expr_LitInt m], _ -> int_of_string n * int_of_string m
@@ -1119,6 +1131,12 @@ module IntToBits = struct
             let (n,nsize) = bits_with_size_of_expr n in
             expr_prim' "lsr_bits" [size; expr_of_int nsize] [x;sym_expr n]
           | Expr_TApply (FIdent ("ASR", 0), [size], [x; n]) ->
+            let (n,nsize) = bits_with_size_of_expr n in
+            expr_prim' "asr_bits" [size; expr_of_int nsize] [x;sym_expr n]
+          | Expr_TApply (FIdent ("ROR", 0), [size], [x; n]) ->
+            let (n,nsize) = bits_with_size_of_expr n in
+            expr_prim' "asr_bits" [size; expr_of_int nsize] [x;sym_expr n]
+          | Expr_TApply (FIdent ("ROL", 0), [size], [x; n]) ->
             let (n,nsize) = bits_with_size_of_expr n in
             expr_prim' "asr_bits" [size; expr_of_int nsize] [x;sym_expr n]
 

--- a/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
@@ -300,7 +300,7 @@ public:
   void f_gen_store(rt_lexpr ptr, rt_expr exp) override {
     return f_gen_array_store(ptr, 0, exp);
   }
- 
+
   rt_expr f_gen_array_load(rt_lexpr var, bigint index) override {
     llvm::Value* ptr{};
     llvm::Type* ty{};
@@ -441,6 +441,16 @@ public:
     auto shift = builder->CreateAShr(x, y);
     auto zero = int_const(wd, 0);
     return builder->CreateSelect(ok, shift, zero);
+  }
+
+  rt_expr f_gen_ror_bits(rt_expr x, rt_expr y) override {
+    assert(0 && "unimplemented");
+    return nullptr;
+  }
+
+  rt_expr f_gen_rol_bits(rt_expr x, rt_expr y) override {
+    assert(0 && "unimplemented");
+    return nullptr;
   }
 
   rt_expr f_gen_replicate_bits(rt_expr x, rt_expr y) override {

--- a/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
@@ -141,6 +141,8 @@ public:
   virtual rt_expr f_gen_lsr_bits(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_lsl_bits(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_asr_bits(rt_expr x, rt_expr y) = 0;
+  virtual rt_expr f_gen_ror_bits(rt_expr x, rt_expr y) = 0;
+  virtual rt_expr f_gen_rol_bits(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_replicate_bits(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_ZeroExtend(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_SignExtend(rt_expr x, rt_expr y) = 0;

--- a/offlineASL-scala/lifter/src/interface.scala
+++ b/offlineASL-scala/lifter/src/interface.scala
@@ -84,6 +84,8 @@ trait LiftState[RTSym, RTLabel, BV <: RTSym] {
   def f_gen_asr_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_lsl_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_lsr_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym
+  def f_gen_ror_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym
+  def f_gen_rol_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_mul_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_ne_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_not_bits(targ0: BigInt, arg0: RTSym): RTSym

--- a/offlineASL-scala/main/src/NoneLifter.scala
+++ b/offlineASL-scala/main/src/NoneLifter.scala
@@ -5,7 +5,7 @@ import lifter._
  * User-provided implementation of the lift-time semantics (e.g. f_eq_bits) and IBI (e.g. f_gen_eq_bits).
  */
 
-sealed trait RExpr 
+sealed trait RExpr
 case class BitVec(val value: BigInt, val size: BigInt) extends RExpr
 case class OtherExpr() extends RExpr
 
@@ -95,6 +95,8 @@ class NotImplementedLifter extends LiftState[RExpr, String, BitVec] {
   def f_gen_asr_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_lsl_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_lsr_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
+  def f_gen_ror_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
+  def f_gen_rol_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_mul_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_ne_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_not_bits(targ0: BigInt, arg0: RTSym): RTSym = throw NotImplementedError()

--- a/offlineASL/offline_utils.ml
+++ b/offlineASL/offline_utils.ml
@@ -241,6 +241,10 @@ let f_gen_lsl_bits xw yw x y =
   Expr_TApply (FIdent ("lsl_bits", 0), [expr_of_z xw; expr_of_z yw], [x;y])
 let f_gen_asr_bits xw yw x y =
   Expr_TApply (FIdent ("asr_bits", 0), [expr_of_z xw; expr_of_z yw], [x;y])
+let f_gen_ror_bits xw yw x y =
+  Expr_TApply (FIdent ("ror_bits", 0), [expr_of_z xw; expr_of_z yw], [x;y])
+let f_gen_rol_bits xw yw x y =
+  Expr_TApply (FIdent ("rol_bits", 0), [expr_of_z xw; expr_of_z yw], [x;y])
 let f_gen_replicate_bits xw yw x y =
   Expr_TApply (FIdent ("replicate_bits", 0), [expr_of_z xw; expr_of_z yw], [x; expr_of_z yw])
 let f_gen_ZeroExtend xw yw x y =

--- a/tests/override.asl
+++ b/tests/override.asl
@@ -51,6 +51,14 @@ bits(N1) asr_bits(bits(N1) x, bits(N2) y)
     integer yn = SInt(y);
     return ASR(x, yn);
 
+bits(N1) ror_bits(bits(N1) x, bits(N2) y)
+    integer yn = SInt(y);
+    return ROR(x, yn);
+
+bits(N1) rol_bits(bits(N1) x, bits(N2) y)
+    integer yn = SInt(y);
+    return ROL(x, yn);
+
 integer HighestSetBit(bits(N) x)
     assert 0 < N && N <= 64;
     if (63 < N && x[63] == '1') then


### PR DESCRIPTION
Treat the `ROR` and `ROL` ASL functions as primitive operations.